### PR TITLE
Fix N5.remove() on NFS

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/N5.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/N5.java
@@ -331,10 +331,11 @@ public class N5
 	    			childPath -> {
 	    				final File childFile = childPath.toFile();
 	    				if (childFile.isFile()) {
-	    					try (final FileLock lock = FileChannel.open(childPath, StandardOpenOption.WRITE).lock()) {
-								childFile.delete();
-								lock.release();
-							} catch (final IOException e) {
+	    					try (final FileChannel channel = FileChannel.open(childPath, StandardOpenOption.WRITE)) {
+		    					final FileLock lock = channel.lock();
+    							childFile.delete();
+		    					if (lock.isValid()) lock.release();
+	    					} catch (final IOException e) {
 								e.printStackTrace();
 							}
 	    				}


### PR DESCRIPTION
N5Test was failing on my machine (Ubuntu, $HOME stored on NFS) due to not being able to remove an N5 dataset. Further debugging showed that it could not delete a directory which should be empty but actually was not.
It turned out that a file channel was never closed after the file deletion, and an auto-generated file .nrsXXXXX was left in that directory. Closing the file channel fixes the issue.